### PR TITLE
fix flaky test on test_api.py::TestFootprint::test_flight and test_api.py::TestFootprint::test_flight_two_way

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,11 +12,14 @@ class TestFootprint(unittest.TestCase):
         self.fp = Footprint()
 
     def test_flight(self):
+        self.fp = Footprint()
         self.fp.add_flight(a="BRU", b="BCN")
         self.assertEqual(len(self.fp.steps), 1)
         self.assertAlmostEqual(self.fp.emissions, 116, delta=5)
 
     def test_flight_two_way(self):
+        self.fp = Footprint()
+        self.fp.add_flight(a="BRU", b="BCN")
         self.fp.add_flight(a="BRU", b="BCN", two_way=True)
         self.assertEqual(len(self.fp.steps), 3)
         self.assertAlmostEqual(self.fp.emissions, 116 * 3, delta=10)


### PR DESCRIPTION
This PR aims to fix the flaky test on **test_api.py::TestFootprint::test_flight** and   **test_api.py::TestFootprint::test_flight_two_way** so that the test could pass when the testing suite runs with random order or repeated runs.

#### The result

The test can pass when running only once, but fail when running the test suit multiple times. Both test method `test_flight` and `test_flight_two_way` has the same error.

#### Steps to reproduce the issue

1.  install pytest flaky finder with `pip install pytest-flakefinder`
2.  run pytest with flake-finder with command  `pytest -k test_api.py --flake-finder`

#### Issue of the code

The reason is each method doesn't initialize the Footprint, although the pytest setUpClass method initialize it, each method assumes an order-dependent testing order which will fail in random order or repeated runs.

#### Proposed solution
Adding one line of initialization of Footprint and add the previous footprint to match the test so each method could succeed in its own.

